### PR TITLE
updating the ami

### DIFF
--- a/groups/alteryx-sandbox/data.tf
+++ b/groups/alteryx-sandbox/data.tf
@@ -64,7 +64,7 @@ data "aws_ami" "alteryx_server_ami" {
   count = var.alteryx_server_ami == "" ? 1 : 0
 
   most_recent = true
-  name_regex  = "^alteryx-server-${var.alteryx_server_ami_version_pattern}$"
+  name_regex  = "^win2019-base-${var.alteryx_server_ami_version_pattern}$"
   owners      = [local.alteryx_server_ami_owner_id ]
 }
 
@@ -72,7 +72,7 @@ data "aws_ami" "alteryx_worker_ami" {
   count = var.alteryx_worker_ami == "" ? 1 : 0
 
   most_recent = true
-  name_regex  = "^alteryx-server-${var.alteryx_worker_ami_version_pattern}$"
+  name_regex  = "^win2019-base-${var.alteryx_worker_ami_version_pattern}$"
   owners      = [local.alteryx_worker_ami_owner_id ]
 }
 


### PR DESCRIPTION
To replace the alteryx ami with the win2029 base. This is due to the sid, uuid and gid not refreshing. 