### PR TITLE
Fixing interpolation-only warning

### DIFF
--- a/groups/alteryx-sandbox/iam.tf
+++ b/groups/alteryx-sandbox/iam.tf
@@ -35,7 +35,7 @@ module "alteryx_server_profile" {
       sid    = "S3AllowListGet"
       effect = "Allow"
       resources = [
-        "${data.aws_s3_bucket.resources.arn}",
+        data.aws_s3_bucket.resources.arn,
         "${data.aws_s3_bucket.resources.arn}/*"
       ]
       actions = [
@@ -83,7 +83,7 @@ module "alteryx_worker_profile" {
       sid    = "S3AllowListGet"
       effect = "Allow"
       resources = [
-        "${data.aws_s3_bucket.resources.arn}",
+        data.aws_s3_bucket.resources.arn,
         "${data.aws_s3_bucket.resources.arn}/*"
       ]
       actions = [

--- a/groups/alteryx-sandbox/locals.tf
+++ b/groups/alteryx-sandbox/locals.tf
@@ -7,7 +7,7 @@ locals {
   azure_dc_cidrs = jsondecode(local.secrets.azure_dc_cidrs)
   azure_cidrs    = join(",", local.azure_dc_cidrs)
   concourse_cidrs             = local.automation_subnet_cidrs
-  ansible_cidr_blocks         = join(",", "${local.internal_cidrs}", "${local.concourse_cidrs}")
+  ansible_cidr_blocks         = join(",", local.internal_cidrs, local.concourse_cidrs)
   account_ids_secrets         = jsondecode(data.vault_generic_secret.account_ids.data_json)
   vpc_name                    = local.secrets.vpc_name
   automation_subnet           = local.secrets.automation_subnets_pattern


### PR DESCRIPTION
Fixing interpolation-only warning for S3 and ansible cidr